### PR TITLE
fix: escape unknown type output for blocks+marks

### DIFF
--- a/.changeset/clever-moons-brake.md
+++ b/.changeset/clever-moons-brake.md
@@ -1,0 +1,13 @@
+---
+'@portabletext/to-html': patch
+---
+
+fix: escape unknown type/mark names rendered by the fallback components
+
+The default `unknownType` and `unknownMark` components embedded the node's
+`_type`/mark name in their output without escaping it, so a crafted type name
+could inject arbitrary HTML into the rendered output.
+
+Low severity: it only applies when unvalidated Portable Text reaches the
+renderer. Types and marks are normally checked against a known schema before
+being served, which rules this out.

--- a/src/components/unknown.ts
+++ b/src/components/unknown.ts
@@ -1,3 +1,4 @@
+import {escapeHTMLChars} from '../escape'
 import type {PortableTextHtmlComponents} from '../types'
 import {unknownTypeWarning} from '../warnings'
 
@@ -5,7 +6,9 @@ export const DefaultUnknownType: PortableTextHtmlComponents['unknownType'] = ({
   value,
   isInline,
 }) => {
-  const warning = unknownTypeWarning(value._type)
+  // The warning embeds the (user-controlled) `_type`, so it must be escaped
+  // before being placed in the document
+  const warning = escapeHTMLChars(unknownTypeWarning(value._type))
   return isInline
     ? `<span style="display:none">${warning}</span>`
     : `<div style="display:none">${warning}</div>`
@@ -15,7 +18,7 @@ export const DefaultUnknownMark: PortableTextHtmlComponents['unknownMark'] = ({
   markType,
   children,
 }) => {
-  return `<span class="unknown__pt__mark__${markType}">${children}</span>`
+  return `<span class="unknown__pt__mark__${escapeHTMLChars(markType)}">${children}</span>`
 }
 
 export const DefaultUnknownBlockStyle: PortableTextHtmlComponents['unknownBlockStyle'] = ({

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -8,7 +8,18 @@ const charMap: Record<string, string> = {
 }
 
 export function escapeHTML(str: string): string {
-  return replaceMultipleSpaces(str.replace(/[&<>"']/g, (s) => `&${charMap[s]};`))
+  return replaceMultipleSpaces(escapeHTMLChars(str))
+}
+
+/**
+ * Escapes the HTML-significant characters of a string, without the whitespace
+ * normalization that `escapeHTML` applies. Suitable for attribute values and
+ * other places where the input is not user-facing prose.
+ *
+ * @internal
+ */
+export function escapeHTMLChars(str: string): string {
+  return str.replace(/[&<>"']/g, (s) => `&${charMap[s]};`)
 }
 
 export function replaceMultipleSpaces(str: string): string {

--- a/test/escaping.test.ts
+++ b/test/escaping.test.ts
@@ -33,3 +33,82 @@ describe('escaping', () => {
     expect(result).toBe(output)
   })
 })
+
+describe('escaping of unknown types/styles', () => {
+  const payload = `"><img src=x onerror=alert(1)>`
+  const escapedPayload = `&quot;&gt;&lt;img src=x onerror=alert(1)&gt;`
+
+  test('escapes unknown block type', () => {
+    const result = render({_type: payload, _key: 'a'})
+    expect(result).toBe(
+      `<div style="display:none">Unknown block type &quot;${escapedPayload}&quot;, specify a component for it in the \`components.types\` option</div>`,
+    )
+    expect(result).not.toContain(payload)
+  })
+
+  test('escapes unknown inline type', () => {
+    const result = render({
+      _type: 'block',
+      _key: 'a',
+      children: [{_type: payload, _key: 'b'}],
+    })
+    expect(result).toBe(
+      `<p><span style="display:none">Unknown block type &quot;${escapedPayload}&quot;, specify a component for it in the \`components.types\` option</span></p>`,
+    )
+    expect(result).not.toContain(payload)
+  })
+
+  test('escapes unknown mark type', () => {
+    const result = render({
+      _type: 'block',
+      _key: 'a',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'b', marks: [payload], text: 'Hi'}],
+    })
+    expect(result).toBe(`<p><span class="unknown__pt__mark__${escapedPayload}">Hi</span></p>`)
+    expect(result).not.toContain(payload)
+  })
+
+  test('escapes unknown block style', () => {
+    const result = render({
+      _type: 'block',
+      _key: 'a',
+      style: payload,
+      markDefs: [],
+      children: [{_type: 'span', _key: 'b', marks: [], text: 'Hi'}],
+    })
+    expect(result).toBe(`<p>Hi</p>`)
+    expect(result).not.toContain(payload)
+  })
+
+  test('escapes unknown list style', () => {
+    const result = render({
+      _type: 'block',
+      _key: 'a',
+      listItem: payload,
+      level: 1,
+      markDefs: [],
+      children: [{_type: 'span', _key: 'b', marks: [], text: 'Hi'}],
+    })
+    expect(result).toBe(`<ul><li>Hi</li></ul>`)
+    expect(result).not.toContain(payload)
+  })
+
+  test('escapes unknown list item style', () => {
+    const result = render(
+      {
+        _type: 'block',
+        _key: 'a',
+        listItem: payload,
+        level: 1,
+        markDefs: [],
+        children: [{_type: 'span', _key: 'b', marks: [], text: 'Hi'}],
+      },
+      // The default `listItem` component is a catch-all function, so we need a
+      // lookup map in order to hit the `unknownListItem` component
+      {components: {listItem: {}}},
+    )
+    expect(result).toBe(`<ul><li>Hi</li></ul>`)
+    expect(result).not.toContain(payload)
+  })
+})


### PR DESCRIPTION
The default `unknownType` and `unknownMark` components embedded the node's `_type`/mark name in their output without escaping it, so a crafted type name could inject arbitrary HTML into the rendered output.

Note that this only applies when unvalidated Portable Text reaches the renderer. Users are encouraged to always validate portable text structures against a known schema.